### PR TITLE
Fix: resolve Zizmor template and env findings

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       # Test action against local/repository Makefile
       - name: "Run action: ${{ github.repository }} [Local/Makefile]"
@@ -54,6 +56,8 @@ jobs:
 
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       # Run make against a bogus directory/location
       - name: "Run action: ${{ github.repository }} [Failure]"

--- a/action.yaml
+++ b/action.yaml
@@ -32,9 +32,15 @@ runs:
       with:
         repository: "${{ inputs.repository }}"
         path: "${{ inputs.path }}"
+        persist-credentials: false
 
     - name: 'Setup action/environment'
       shell: bash
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+        REPO_PATH: ${{ inputs.path }}
+        MAKE_ARGS: ${{ inputs.make_args }}
+        DEBUG: ${{ inputs.debug }}
       run: |
         # Setup action/environment
 
@@ -49,35 +55,44 @@ runs:
         datetime=$(date +'%Y-%m-%d-%H%M')
         echo "Date and time stamp: $datetime"
 
-        if [ -n "${{ inputs.path }}" ] && \
-          [ -z "${{ inputs.make_args }}" ]; then
+        if [ -n "$REPO_PATH" ] && \
+          [ -z "$MAKE_ARGS" ]; then
           echo 'Repository downloaded to non-local path ⚠️'
-          echo "Suggested make_args: -C ${{ inputs.path }}"
+          echo "Suggested make_args: -C $REPO_PATH"
+          # make_args is intentionally expanded unquoted (word-split)
+          # when make is invoked, so a path containing whitespace
+          # cannot be represented; flag that explicitly rather than
+          # implying shell quoting would help.
+          case "$REPO_PATH" in
+            *[[:space:]]*)
+              echo "Note: make_args uses unquoted word-splitting;" \
+                "paths containing spaces are not supported" ;;
+          esac
         fi
 
         # Output build heading
         echo '# 🔨 Make Action' >> "$GITHUB_STEP_SUMMARY"
         echo "Directory: $PWD" >> "$GITHUB_STEP_SUMMARY"
-        if [ -n "${{ inputs.repository }}" ]; then
-          echo "Repository: ${{ inputs.repository }}" \
+        if [ -n "$REPOSITORY" ]; then
+          echo "Repository: $REPOSITORY" \
             >> "$GITHUB_STEP_SUMMARY"
         fi
-        if [ -n "${{ inputs.path }}" ]; then
-          echo "Path: ${{ inputs.path }}" >> "$GITHUB_STEP_SUMMARY"
+        if [ -n "$REPO_PATH" ]; then
+          echo "Path: $REPO_PATH" >> "$GITHUB_STEP_SUMMARY"
         fi
 
-        debug_lower=$(echo "${{ inputs.debug }}" | tr '[:upper:]' '[:lower:]')
+        debug_lower=$(echo "$DEBUG" | tr '[:upper:]' '[:lower:]')
         if [ "f$debug_lower" = 'ftrue' ]; then
           echo '🐞 Running: find . -name Makefile'
           find . -name Makefile
         fi
 
         # Automatically include -C option when make_args empty and path given
-        if [ -z "${{ inputs.make_args }}" ] && \
-          [ -n "${{ inputs.path }}" ]; then
-          make_args="-C ${{ inputs.path }}"
+        if [ -z "$MAKE_ARGS" ] && \
+          [ -n "$REPO_PATH" ]; then
+          make_args="-C $REPO_PATH"
         else
-          make_args="${{ inputs.make_args }}"
+          make_args="$MAKE_ARGS"
         fi
 
         if "$make_cmd" $make_args; then


### PR DESCRIPTION
## Summary

Resolves all 15 Zizmor findings reported by the org-wide security audit:
12 × `template-injection` and 3 × `artipacked`.

## Fix

**`action.yaml` — template-injection**

- Route the `repository`, `path`, `make_args` and `debug` inputs through
  the `Setup action/environment` step's `env:` block and reference each
  as a quoted shell variable, so nothing is interpolated directly into
  the `run:` body. The `path` input is deliberately mapped to
  `REPO_PATH` (not `PATH`) to avoid clobbering the executable search
  path.

**`action.yaml` + `.github/workflows/testing.yaml` — artipacked**

- Set `persist-credentials: false` on the clone step and on both
  checkout steps in the test workflow.

Behaviour is preserved (including the intentional unquoted expansion of
`$make_args` when invoking `make`).

## Verification

```
uvx zizmor@1.25.2 --persona regular --min-severity medium make-action
# No findings to report. Good job! (4 suppressed)
```

`yamllint`, `actionlint`, `check-yaml` and `Validate GitHub Actions`
pre-commit hooks pass.